### PR TITLE
Add Signature-Agent within Signature-Input and test vectors

### DIFF
--- a/packages/http-message-sig/src/index.ts
+++ b/packages/http-message-sig/src/index.ts
@@ -1,6 +1,7 @@
+export * as base64 from "./base64";
+export { extractHeader } from './/build';
 export * from "./consts";
+export { parseAcceptSignatureHeader as parseAcceptSignature } from "./parse";
 export * from "./sign";
 export * from "./types";
 export * from "./verify";
-export { parseAcceptSignatureHeader as parseAcceptSignature } from "./parse";
-export * as base64 from "./base64";

--- a/packages/http-message-sig/src/index.ts
+++ b/packages/http-message-sig/src/index.ts
@@ -1,5 +1,5 @@
 export * as base64 from "./base64";
-export { extractHeader } from './/build';
+export { extractHeader } from "./build";
 export * from "./consts";
 export { parseAcceptSignatureHeader as parseAcceptSignature } from "./parse";
 export * from "./sign";

--- a/packages/web-bot-auth/package.json
+++ b/packages/web-bot-auth/package.json
@@ -14,6 +14,7 @@
   },
   "scripts": {
     "build": "tsup src/index.ts --format cjs,esm --dts --clean",
+    "generate-test-vectors": "node --experimental-transform-types scripts/test-vectors.ts test/test_data/web_bot_auth_architecture_v1.json",
     "prepublishOnly": "npm run build",
     "test": "vitest",
     "watch": "npm run build -- --watch src"

--- a/packages/web-bot-auth/scripts/test-vectors.ts
+++ b/packages/web-bot-auth/scripts/test-vectors.ts
@@ -1,0 +1,157 @@
+/// This script generates test vectors for https://datatracker.ietf.org/doc/draft-meunier-http-message-signatures-directory/
+/// The vectors are generated in JSON format
+///
+/// It takes one positional argument: [path] which is where the vectors should be written in JSON
+
+const { generateNonce, helpers, jwkToKeyID, signatureHeaders } = await import(
+  "../src/index.ts"
+);
+
+const fs = await import("fs");
+const jwk = JSON.parse(
+  await fs.promises.readFile("../../examples/rfc9421-keys/ed25519.json", "utf8")
+);
+
+const SIGNATURE_AGENT_DOMAIN = "signature-agent.test";
+const ORIGIN_URL = "https://example.com/path/to/resource";
+
+class Ed25519Signer {
+  public alg: Algorithm = "ed25519";
+  public keyid: string;
+  private privateKey: CryptoKey;
+
+  constructor(keyid: string, privateKey: CryptoKey) {
+    this.keyid = keyid;
+    this.privateKey = privateKey;
+  }
+
+  static async fromJWK(jwk: JsonWebKey): Promise<Ed25519Signer> {
+    const key = await crypto.subtle.importKey(
+      "jwk",
+      jwk,
+      { name: "Ed25519" },
+      true,
+      ["sign"]
+    );
+    const keyid = await jwkToKeyID(
+      jwk,
+      helpers.WEBCRYPTO_SHA256,
+      helpers.BASE64URL_DECODE
+    );
+    return new Ed25519Signer(keyid, key);
+  }
+
+  async sign(data: string): Promise<Uint8Array> {
+    const message = new TextEncoder().encode(data);
+    const signature = await crypto.subtle.sign(
+      "ed25519",
+      this.privateKey,
+      message
+    );
+    return new Uint8Array(signature);
+  }
+}
+
+interface TestVector {
+  key: JsonWebKey;
+  target_url: string;
+  created_ms: number;
+  expires_ms: number;
+  nonce: string;
+  label: string;
+  signature: string;
+  signature_input: string;
+  signature_agent?: string;
+}
+
+async function generateTestVectors(): Promise<TestVector[]> {
+  const now = new Date("2025-01-01T00:00:00Z");
+  const created = now;
+  const expires = new Date(now.getTime() + 3_600_000);
+  const signer = await Ed25519Signer.fromJWK(jwk);
+
+  const nonce = generateNonce();
+  const label = "sig1";
+  let request = new Request(ORIGIN_URL);
+  const signedHeaders = await signatureHeaders(request, signer, {
+    created,
+    expires,
+    nonce,
+    key: label,
+  });
+
+  const nonceWithAgent = generateNonce();
+  const labelWithAgent = "sig2";
+  request = new Request(ORIGIN_URL, {
+    headers: { "Signature-Agent": SIGNATURE_AGENT_DOMAIN },
+  });
+  const signedHeadersWithAgent = await signatureHeaders(request, signer, {
+    created,
+    expires,
+    nonce: nonceWithAgent,
+    key: labelWithAgent,
+  });
+
+  return [
+    {
+      key: jwk,
+      target_url: ORIGIN_URL,
+      created_ms: created.getTime(),
+      expires_ms: expires.getTime(),
+      nonce,
+      label,
+      signature: signedHeaders["Signature"],
+      signature_input: signedHeaders["Signature-Input"],
+    },
+    {
+      key: jwk,
+      target_url: ORIGIN_URL,
+      created_ms: created.getTime(),
+      expires_ms: expires.getTime(),
+      nonce: nonceWithAgent,
+      label: labelWithAgent,
+      signature: signedHeadersWithAgent["Signature"],
+      signature_input: signedHeadersWithAgent["Signature-Input"],
+      signature_agent: SIGNATURE_AGENT_DOMAIN,
+    },
+  ];
+}
+
+const outputPath = process.argv[2];
+
+if (!outputPath) {
+  console.error("Please provide a file path as the first argument.");
+  process.exit(1);
+}
+
+const vectors = await generateTestVectors();
+
+for (const vector of vectors) {
+  console.log(`Signature base
+
+NOTE: '\\' line wrapping per RFC 8792
+`);
+  console.log(`"@authority": ${new URL(vector.target_url).host}`);
+  if (vector.signature_agent) {
+    console.log(`"signature-agent": ${vector.signature_agent}`);
+  }
+  console.log(
+    `"@signature-params": ${vector.signature_input.slice(`${vector.label}=`.length).replaceAll(";", "\\\n ;")}`
+  );
+  console.log("");
+
+  console.log(`Signature headers
+
+NOTE: '\\' line wrapping per RFC 8792
+`);
+  if (vector.signature_agent) {
+    console.log(`Signature-Agent: ${vector.signature_agent}`);
+  }
+  console.log(
+    `Signature-Input: ${vector.signature_input.replaceAll(";", "\\\n ;")}`
+  );
+  console.log(`Signature: ${vector.signature}`);
+  console.log("");
+}
+
+fs.writeFileSync(outputPath, JSON.stringify(vectors, null, 2), "utf-8");

--- a/packages/web-bot-auth/src/index.ts
+++ b/packages/web-bot-auth/src/index.ts
@@ -11,14 +11,20 @@ import { b64ToB64URL, b64ToB64NoPadding, b64Tou8, u8ToB64 } from "./base64";
 
 export const HTTP_MESSAGE_SIGNAGURE_TAG = "web-bot-auth";
 export const SIGNATURE_AGENT_HEADER = "signature-agent";
-export const REQUEST_COMPONENTS_WITHOUT_SIGNATURE_AGENT: httpsig.Component[] = ["@authority"];
-export const REQUEST_COMPONENTS: httpsig.Component[] = ["@authority", SIGNATURE_AGENT_HEADER];
+export const REQUEST_COMPONENTS_WITHOUT_SIGNATURE_AGENT: httpsig.Component[] = [
+  "@authority",
+];
+export const REQUEST_COMPONENTS: httpsig.Component[] = [
+  "@authority",
+  SIGNATURE_AGENT_HEADER,
+];
 export const NONCE_LENGTH_IN_BYTES = 64;
 
 export interface SignatureParams {
   created: Date;
   expires: Date;
   nonce?: string;
+  key?: string;
 }
 
 export interface VerificationParams {
@@ -75,6 +81,7 @@ export function signatureHeaders<
     expires: params.expires,
     nonce,
     keyid: signer.keyid,
+    key: params.key,
     tag: HTTP_MESSAGE_SIGNAGURE_TAG,
   });
 }

--- a/packages/web-bot-auth/test/index.test.ts
+++ b/packages/web-bot-auth/test/index.test.ts
@@ -1,10 +1,75 @@
 import { describe, it, expect } from "vitest";
 import {
   generateNonce,
+  helpers,
+  jwkToKeyID,
+  signatureHeaders,
   validateNonce,
   NONCE_LENGTH_IN_BYTES,
+  SIGNATURE_AGENT_HEADER,
 } from "../src/index";
 import { b64Tou8, u8ToB64 } from "../src/base64";
+
+import vectors from "./test_data/web_bot_auth_architecture_v1.json";
+type Vectors = (typeof vectors)[number];
+
+class Ed25519Signer {
+  public alg: Algorithm = "ed25519";
+  public keyid: string;
+  private privateKey: CryptoKey;
+
+  constructor(keyid: string, privateKey: CryptoKey) {
+    this.keyid = keyid;
+    this.privateKey = privateKey;
+  }
+
+  static async fromJWK(jwk: JsonWebKey): Promise<Ed25519Signer> {
+    const key = await crypto.subtle.importKey(
+      "jwk",
+      jwk,
+      { name: "Ed25519" },
+      true,
+      ["sign"]
+    );
+    const keyid = await jwkToKeyID(
+      jwk,
+      helpers.WEBCRYPTO_SHA256,
+      helpers.BASE64URL_DECODE
+    );
+    return new Ed25519Signer(keyid, key);
+  }
+
+  async sign(data: string): Promise<Uint8Array> {
+    const message = new TextEncoder().encode(data);
+    const signature = await crypto.subtle.sign(
+      "ed25519",
+      this.privateKey,
+      message
+    );
+    return new Uint8Array(signature);
+  }
+}
+
+describe.each(vectors)("Web-bot-auth-ed25519-Vector-%#", (v: Vectors) => {
+  it("should pass IETF draft test vectors", async () => {
+    const signer = await Ed25519Signer.fromJWK(v.key);
+
+    const headers = new Headers();
+    if (v.signature_agent) {
+      headers.append(SIGNATURE_AGENT_HEADER, v.signature_agent);
+    }
+    const request = new Request(v.target_url, { headers });
+    const signedHeaders = await signatureHeaders(request, signer, {
+      created: new Date(v.created_ms),
+      expires: new Date(v.expires_ms),
+      nonce: v.nonce,
+      key: v.label,
+    });
+
+    expect(signedHeaders["Signature-Input"]).toBe(v.signature_input);
+    expect(signedHeaders["Signature"]).toBe(v.signature);
+  });
+});
 
 describe("nonce", () => {
   describe("generateNonce", () => {

--- a/packages/web-bot-auth/test/test_data/web_bot_auth_architecture_v1.json
+++ b/packages/web-bot-auth/test/test_data/web_bot_auth_architecture_v1.json
@@ -1,0 +1,35 @@
+[
+  {
+    "key": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "kid": "test-key-ed25519",
+      "d": "n4Ni-HpISpVObnQMW0wOhCKROaIKqKtW_2ZYb2p9KcU",
+      "x": "JrQLj5P_89iXES9-vFgrIy29clF9CC_oPPsw3c5D0bs"
+    },
+    "target_url": "https://example.com/path/to/resource",
+    "created_ms": 1735689600000,
+    "expires_ms": 1735693200000,
+    "nonce": "gubxywVx7hzbYKatLgzuKDllDAIXAkz41PydU7aOY7vT+Mb3GJNxW0qD4zJ+IOQ1NVtg+BNbTCRUMt1Ojr5BgA==",
+    "label": "sig1",
+    "signature": "sig1=:uz2SAv+VIemw+Oo890bhYh6Xf5qZdLUgv6/PbiQfCFXcX/vt1A8Pf7OcgL2yUDUYXFtffNpkEr5W6dldqFrkDg==:",
+    "signature_input": "sig1=(\"@authority\");created=1735689600;keyid=\"poqkLGiymh_W0uP6PZFw-dvez3QJT5SolqXBCW38r0U\";alg=\"ed25519\";expires=1735693200;nonce=\"gubxywVx7hzbYKatLgzuKDllDAIXAkz41PydU7aOY7vT+Mb3GJNxW0qD4zJ+IOQ1NVtg+BNbTCRUMt1Ojr5BgA==\";tag=\"web-bot-auth\""
+  },
+  {
+    "key": {
+      "kty": "OKP",
+      "crv": "Ed25519",
+      "kid": "test-key-ed25519",
+      "d": "n4Ni-HpISpVObnQMW0wOhCKROaIKqKtW_2ZYb2p9KcU",
+      "x": "JrQLj5P_89iXES9-vFgrIy29clF9CC_oPPsw3c5D0bs"
+    },
+    "target_url": "https://example.com/path/to/resource",
+    "created_ms": 1735689600000,
+    "expires_ms": 1735693200000,
+    "nonce": "ZO3/XMEZjrvSnLtAP9M7jK0WGQf3J+pbmQRUpKDhF9/jsNCWqUh2sq+TH4WTX3/GpNoSZUa8eNWMKqxWp2/c2g==",
+    "label": "sig2",
+    "signature": "sig2=:bcWij+p0SZDQ0hF7Bk8scjEVRMJZlk1EzEHEHUzT58VbPWRrdIRYJgYerlC4fZ01v/hlsbnLvLDrrA5fBeb1CA==:",
+    "signature_input": "sig2=(\"@authority\" \"signature-agent\");created=1735689600;keyid=\"poqkLGiymh_W0uP6PZFw-dvez3QJT5SolqXBCW38r0U\";alg=\"ed25519\";expires=1735693200;nonce=\"ZO3/XMEZjrvSnLtAP9M7jK0WGQf3J+pbmQRUpKDhF9/jsNCWqUh2sq+TH4WTX3/GpNoSZUa8eNWMKqxWp2/c2g==\";tag=\"web-bot-auth\"",
+    "signature_agent": "signature-agent.test"
+  }
+]


### PR DESCRIPTION
When provided, Signature-Agent is included in Signature-Input This is done per the latest version of the draft.

Tests to be done in a following commit

cc @AkshatM